### PR TITLE
DE156382; Hyper Android | Dots do not show up on dates which only hav…

### DIFF
--- a/collapsiblecalendarview2/src/main/java/com/hyperexternal/collapsiblecalendarview/widget/CollapsibleCalendar.kt
+++ b/collapsiblecalendarview2/src/main/java/com/hyperexternal/collapsiblecalendarview/widget/CollapsibleCalendar.kt
@@ -397,15 +397,22 @@ open class CollapsibleCalendar : UICalendar, View.OnClickListener {
         reload()
     }
 
-    fun addAllEvent(eventList: List<Event>) {
-        mAdapter!!.mEventList = eventList.toMutableSet()
-        reload()
-    }
-
     fun addEventTag(numYear: Int, numMonth: Int, numDay: Int, color: Int) {
         mAdapter!!.addEvent(Event(numYear, numMonth, numDay, color))
 
+        reload()
+    }
 
+    fun addEventTagFromList(eventList: List<Event>) {
+        for (event in eventList) {
+            mAdapter!!.addEvent(Event(event.year, event.month, event.day, eventColor))
+        }
+
+        reload()
+    }
+
+    fun addAllEvent(eventList: List<Event>) {
+        mAdapter!!.mEventList = eventList.toMutableSet()
         reload()
     }
 


### PR DESCRIPTION
…e recurring events until kill and re-open app

Added in a new API to add tags for a list of events before calling `reload()`. This allows us to prevent the UI from freezing up due to constant reloads if many dates are added, such as from adding recurring events.