### PR TITLE
F34032; Allow calendar month to be read

### DIFF
--- a/collapsiblecalendarview2/src/main/res/layout/widget_collapsible_calendarview.xml
+++ b/collapsiblecalendarview2/src/main/res/layout/widget_collapsible_calendarview.xml
@@ -86,6 +86,7 @@
                 android:id="@+id/txt_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:focusable="true"
                 android:fontFamily="sans-serif-medium"
                 android:paddingStart="8dp"
                 android:paddingEnd="10dp"


### PR DESCRIPTION
Give the textview for the month focusable to allow it to be read by talkback while also allowing its parent view to be clickable to allow expand/collapse of the calendar.